### PR TITLE
Add support for xfce4-terminal

### DIFF
--- a/src/budgie_desktop_view.vala
+++ b/src/budgie_desktop_view.vala
@@ -42,7 +42,8 @@ public const string[] SUPPORTED_TERMINALS = {
 	"konsole",
 	"mate-terminal",
 	"terminator",
-	"tilix"
+	"tilix",
+	"xfce4-terminal"
 };
 
 public class DesktopView : Gtk.ApplicationWindow {
@@ -475,7 +476,7 @@ public class DesktopView : Gtk.ApplicationWindow {
 	// get_all_desktop_files will get all the files in our Desktop folder and generate items for them
 	private void get_all_desktop_files() {
 		var c = new Cancellable(); // Create a new cancellable stack
-		FileEnumerator? desktop_file_enumerator = null; 
+		FileEnumerator? desktop_file_enumerator = null;
 
 		try {
 			desktop_file_enumerator = desktop_file.enumerate_children("standard::*,standard::display-name", FileQueryInfoFlags.NONE, c);

--- a/src/file_item.vala
+++ b/src/file_item.vala
@@ -275,9 +275,9 @@ public class FileItem : DesktopItem {
 					args += editor;
 					args += path;
 				} else {
+					string[] cmd = { editor, path };
 					args += "-e";
-					args += editor;
-					args += path;
+					args += string.joinv(" ", cmd); // join command so that it is one argument
 				}
 			}
 

--- a/src/file_item.vala
+++ b/src/file_item.vala
@@ -233,16 +233,25 @@ public class FileItem : DesktopItem {
 			// konsole supports --new-tab and -e, --workdir WITHOUT equal
 			// kitty supports --directory WITH equal
 			// terminator supports --new-tab and -e,  --working-directory (no -w) WITH equal
-			// tilix uses just -e, supports both --working-directory and -w WITH equal
-			if (
-				(preferred_terminal != "alacritty") && // Not Alacritty, no tab CLI flag
-				(preferred_terminal != "gnome-terminal") && // Not GNOME Terminal which uses --tab instead of --new-tab
-				(preferred_terminal != "tilix") && // No new tab CLI flag (that I saw anyways)
-				(preferred_terminal != "kitty") // No new tab CLI flag for Kitty, either
-			) {
-				args += "--new-tab"; // Add --new-tab
-			} else if ((preferred_terminal == "gnome-terminal") && (_type == "file")) { // GNOME Terminal, self explanatory really
-				args += "--tab"; // Create a new tab in an existing window or creates a new window
+			// xfce4-terminal supports -e, --tab, --window, and --working-directory (no -w) WITH equal
+
+			switch (preferred_terminal) {
+				// Terminals that use --tab
+				case "gnome-terminal":
+				case "mate-terminal":
+				case "xfce4-terminal":
+					args += "--tab";
+					break;
+
+				// Terminals that use --new-tab
+				case "konsole":
+				case "terminator":
+					args += "--new-tab";
+					break;
+
+				// Terminals that don't support tabs
+				default:
+					break;
 			}
 
 			string path =  file.get_path();


### PR DESCRIPTION
Add support for xfce4-terminal.
Additionally refactored the logic for opening the terminal in a new tab.

Git also caught a trailing space.