### PR TITLE
Add Nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 *.tar.xz*
+result*

--- a/README.md
+++ b/README.md
@@ -111,6 +111,40 @@ Budgie Desktop View can be uninstalled using this command:
 sudo ninja -C build uninstall
 ```
 
+## Nix
+
+Integration with the Nix package manager is provided in the [`nix`](./nix) directory.
+
+### Development Shell
+
+A Nix development shell including all build-time dependencies is available, to enter it running `nix-shell ./nix/shell.nix` or `nix develop ./nix` if the Flakes feature is enabled.
+
+### Package
+
+A Nix package is available, to build it run `nix-build -E "with import <nixpkgs> {}; callPackage ./nix {}"` or `nix build ./nix` if the Flakes feature is enabled.
+
+To import the package into a Nix expression, use the following:
+
+```nix
+let
+  budgie-desktop-view-src = fetchTarball "https://github.com/BuddiesOfBudgie/budgie-desktop-view/archive/master.tar.gz";
+  budgie-desktop-view = import (budgie-desktop-view-src + "/nix");
+in
+  budgie-desktop-view
+```
+
+### Flake
+
+A Nix Flake is available, to import it add the following to your `flake.nix`:
+
+```nix
+# Provides:
+#   Development Shell: devShells.default
+#   Package:           packages.${system}.budgie-desktop-view (alias: default)
+inputs.budgie-desktop-view.url = "github:BuddiesOfBudgie/budgie-desktop-view";
+inputs.budgie-desktop-view.inputs.nixpkgs.follows = "nixpkgs"; # Recommended.
+```
+
 ## License
 
 Budgie Desktop View is licensed under the Apache-2.0 license.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  desktop-file-utils,
+  gtk3,
+  intltool,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  wrapGAppsHook,
+}:
+stdenv.mkDerivation {
+  pname = "budgie-desktop-view";
+  version = "unstable";
+
+  src = lib.cleanSource ../.;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    intltool
+    desktop-file-utils
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+  ];
+
+  meta = with lib; {
+    description = "Official Budgie desktop icons application/implementation";
+    longDescription = ''
+      Budgie Desktop View is the official Budgie desktop icons application/implementation.
+    '';
+    homepage = "https://blog.buddiesofbudgie.org/";
+    downloadPage = "https://github.com/BuddiesOfBudgie/budgie-desktop-view/releases";
+    mainProgram = "org.buddiesofbudgie.budgie-desktop-view";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+  };
+}

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671458120,
+        "narHash": "sha256-2+k/OONN4OF21TeoNjKB5sXVZv6Zvm/uEyQIW9OYCg8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e37ef84b478fa8da0ced96522adfd956fde9047a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = {nixpkgs, ...}: let
+    forAllSystems = f: nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"] (system: f nixpkgs.legacyPackages.${system});
+  in {
+    packages = forAllSystems (pkgs: rec {
+      budgie-desktop-view = pkgs.callPackage ./. {};
+      default = budgie-desktop-view;
+    });
+
+    devShells = forAllSystems (pkgs: {
+      default = import ./shell.nix {inherit pkgs;};
+    });
+
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,15 @@
+{pkgs ? import <nixpkgs> {}}:
+with pkgs;
+  mkShell {
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      vala
+      intltool
+    ];
+
+    buildInputs = [
+      gtk3
+    ];
+  }

--- a/scripts/mesonPostInstall.sh
+++ b/scripts/mesonPostInstall.sh
@@ -9,6 +9,6 @@ if [ -z $DESTDIR ]; then
 	echo 'Compiling GSchema'
 	glib-compile-schemas "$PREFIX/share/glib-2.0/schemas"
 	echo 'Updating desktop database'
-	update-desktop-database -q
+	update-desktop-database -q "$PREFIX/share/applications"
 
 fi


### PR DESCRIPTION
This commit provides a Nix-based package definition and development shell. A Flake is also provided for environments where that feature is enabled.

To build the package derivation use `nix build` (with Flakes) or `nix-build -E "with import <nixpkgs> {}; callPackage ./. {}"` (without Flakes).

To enter the development shell, run `nix develop` (with Flakes) or `nix-shell` (without Flakes).