### PR TITLE
Use correct path for building xdg_appdir value.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ if xdg_appdir == ''
 	if with_stateless == true
 		xdg_appdir = join_paths(datadir, 'xdg', 'autostart')
 	else
-		xdg_appdir = join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
+		xdg_appdir = join_paths(confdir, 'xdg', 'autostart')
 	endif
 endif
 


### PR DESCRIPTION
The get_option('sysconfdir') by itself doesn't contain prefix. Use `confdir` variable instead, which is in line with `datadir` variable usage.

Original patch by Olivier Duchateau <duchateau.olivier@gmail.com> @OlivierDuchateau