### PR TITLE
Add translation support for trash icon

### DIFF
--- a/src/budgie_desktop_view.vala
+++ b/src/budgie_desktop_view.vala
@@ -318,7 +318,7 @@ public class DesktopView : Gtk.ApplicationWindow {
 		special_item.file_type = item_type; // Override file_type
 
 		if (item_type == "trash") {
-			special_item.label_name = "Trash";
+			special_item.label_name = _("Trash");
 		}
 
 		return special_item;


### PR DESCRIPTION
This commit adds translation support for the trash icon label.