### PR TITLE
Don't require nautilus for trash icon

### DIFF
--- a/src/file_item.vala
+++ b/src/file_item.vala
@@ -310,7 +310,7 @@ public class FileItem : DesktopItem {
 		}
 
 		try {
-			if ((file_type == "trash") && (appinfo.get_id() == "org.gnome.Nautilus.desktop")) { // Is trash and using Nautilus
+			if (file_type == "trash") { // Is trash
 				List<string> trash_uris = new List<string>();
 				trash_uris.append("trash:///"); // Open as trash:/// so Nautilus can show us the empty banner
 				appinfo.launch_uris(trash_uris, launch_context);


### PR DESCRIPTION
Without this change, clicking the trash icon would open up the trash directory under `~/.local/share` instead of the `trash:///` uri. Every other file manager I have tested (`nemo`, `thunar`, `dolphin`,` pcmanfm`) support this location anyway. Is there a reason for this check? 

Fixes: #6