### PR TITLE
Add GNOME Console to supported terminals

### DIFF
--- a/src/budgie_desktop_view.vala
+++ b/src/budgie_desktop_view.vala
@@ -37,6 +37,7 @@ public const int ITEM_MARGIN = 10;
 public const string[] SUPPORTED_TERMINALS = {
 	"alacritty",
 	"gnome-terminal",
+	"kgx",
 	"kitty",
 	"konsole",
 	"mate-terminal",

--- a/src/file_item.vala
+++ b/src/file_item.vala
@@ -234,12 +234,16 @@ public class FileItem : DesktopItem {
 			if (
 				(preferred_terminal != "alacritty") && // Not Alacritty, no tab CLI flag
 				(preferred_terminal != "gnome-terminal") && // Not GNOME Terminal which uses --tab instead of --new-tab
+				(preferred_terminal != "kgx") && // Not GNOME Console which uses --tab instead of --new-tab
 				(preferred_terminal != "mate-terminal") && // Not Mate Terminal which uses --tab instead of --new-tab
 				(preferred_terminal != "tilix") && // No new tab CLI flag (that I saw anyways)
 				(preferred_terminal != "kitty") // No new tab CLI flag for Kitty, either
 			) {
 				args += "--new-tab"; // Add --new-tab
-			} else if ((preferred_terminal == "gnome-terminal" || preferred_terminal == "mate-terminal") && (_type == "file")) {
+			} else if (
+			    (preferred_terminal == "gnome-terminal" || preferred_terminal == "kgx" || preferred_terminal == "mate-terminal") &&
+			    (_type == "file")
+			) {
 				args += "--tab"; // Create a new tab in an existing window or creates a new window
 			}
 


### PR DESCRIPTION
GNOME Console (`kgx`) is the default terminal in GNOME [since version 42](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/commit/307478d65112c7b63946b6eb61c441f139f40942).