### PR TITLE
DesktopMenu: Adapt to new BCC deskop file name

### DIFF
--- a/src/desktop_menu.vala
+++ b/src/desktop_menu.vala
@@ -24,11 +24,8 @@ public class DesktopMenu : Gtk.Menu {
 	public DesktopMenu() {
 		Object();
 
-		budgie_app = new DesktopAppInfo("budgie-desktop-settings.desktop");
-		if (!(budgie_app is DesktopAppInfo)) {
-			budgie_app = new DesktopAppInfo("org.buddiesofbudgie.BudgieDesktopSettings.desktop");
-		}
-		bcc_app = new DesktopAppInfo("budgie-control-center.desktop");
+		budgie_app = new DesktopAppInfo("org.buddiesofbudgie.BudgieDesktopSettings.desktop");
+		bcc_app = new DesktopAppInfo("org.buddiesofbudgie.ControlCenter.desktop");
 
 		Gtk.MenuItem budgie_item = new Gtk.MenuItem.with_label(_("Budgie Desktop Settings"));
 		Gtk.MenuItem system_item = new Gtk.MenuItem.with_label(_("System Settings"));


### PR DESCRIPTION
Also clean up old fallbacks since it is not expected to run wayland-based budgie-desktop-view on X11-based budgie-desktop...

ref: https://github.com/BuddiesOfBudgie/budgie-control-center/commit/81e2c011d4aa220b91f363db5e81962fec5dbb3f